### PR TITLE
feat(view-account): switched `view account-summary` command from displaying raw data to human-readable format

### DIFF
--- a/src/commands/add_command/access_key/public_key_mode/add_access_key/function_call_type/mod.rs
+++ b/src/commands/add_command/access_key/public_key_mode/add_access_key/function_call_type/mod.rs
@@ -28,12 +28,7 @@ pub struct FunctionCallType {
 impl From<CliFunctionCallType> for FunctionCallType {
     fn from(item: CliFunctionCallType) -> Self {
         let allowance: Option<near_primitives::types::Balance> = match item.allowance {
-            Some(cli_allowance) => {
-                let allowance = match cli_allowance {
-                    crate::common::NearBalance { inner: num } => num,
-                };
-                Some(allowance)
-            }
+            Some(cli_allowance) => Some(cli_allowance.to_yoctonear()),
             None => FunctionCallType::input_allowance(),
         };
         let receiver_id: near_primitives::types::AccountId = match item.receiver_id {
@@ -120,10 +115,7 @@ impl FunctionCallType {
                     .with_prompt("Enter an allowance which is a balance limit to use by this access key to pay for function call gas and transaction fees.")
                     .interact_text()
                     .unwrap();
-                let allowance = match allowance_near_balance {
-                    crate::common::NearBalance { inner: num } => num,
-                };
-                Some(allowance)
+                Some(allowance_near_balance.to_yoctonear())
             }
             Some(1) => None,
             _ => unreachable!("Error"),

--- a/src/commands/add_command/contract_code/contract/initialize_mode/call_function_type/mod.rs
+++ b/src/commands/add_command/contract_code/contract/initialize_mode/call_function_type/mod.rs
@@ -42,9 +42,7 @@ impl From<CliCallFunctionAction> for CallFunctionAction {
             None => CallFunctionAction::input_gas(),
         };
         let deposit: near_primitives::types::Balance = match item.deposit {
-            Some(cli_deposit) => match cli_deposit {
-                crate::common::NearBalance { inner: num } => num,
-            },
+            Some(cli_deposit) => cli_deposit.to_yoctonear(),
             None => CallFunctionAction::input_deposit(),
         };
         let sign_option = match item.sign_option {
@@ -105,12 +103,10 @@ impl CallFunctionAction {
             .with_prompt(
                 "Enter a deposit for function (example: 10NEAR or 0.5near or 10000yoctonear).",
             )
-            .with_initial_text("0 Near")
+            .with_initial_text("0 NEAR")
             .interact_text()
             .unwrap();
-        match deposit {
-            crate::common::NearBalance { inner: num } => num,
-        }
+        deposit.to_yoctonear()
     }
 
     pub async fn process(

--- a/src/commands/add_command/stake_proposal/transfer_near_tokens_type/mod.rs
+++ b/src/commands/add_command/stake_proposal/transfer_near_tokens_type/mod.rs
@@ -85,14 +85,11 @@ impl TransferNEARTokensAction {
         prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
         selected_server_url: Option<url::Url>,
     ) -> crate::CliResult {
-        let stake = match self.amount {
-            crate::common::NearBalance { inner: num } => num,
-        };
         self.sign_transactions
             .process(
                 prepopulated_unsigned_transaction,
                 selected_server_url,
-                stake,
+                self.amount.to_yoctonear(),
             )
             .await
     }

--- a/src/commands/add_command/sub_account/deposit/mod.rs
+++ b/src/commands/add_command/sub_account/deposit/mod.rs
@@ -88,11 +88,10 @@ impl TransferNEARTokensAction {
         prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
         selected_server_url: Option<url::Url>,
     ) -> crate::CliResult {
-        let amount = match self.amount {
-            crate::common::NearBalance { inner: num } => num,
-        };
         let action = near_primitives::transaction::Action::Transfer(
-            near_primitives::transaction::TransferAction { deposit: amount },
+            near_primitives::transaction::TransferAction {
+                deposit: self.amount.to_yoctonear(),
+            },
         );
         let mut actions = prepopulated_unsigned_transaction.actions.clone();
         actions.push(action);

--- a/src/commands/construct_transaction_command/transaction_actions/add_access_key_type/function_call_type/mod.rs
+++ b/src/commands/construct_transaction_command/transaction_actions/add_access_key_type/function_call_type/mod.rs
@@ -26,12 +26,7 @@ pub struct FunctionCallType {
 impl From<CliFunctionCallType> for FunctionCallType {
     fn from(item: CliFunctionCallType) -> Self {
         let allowance: Option<near_primitives::types::Balance> = match item.allowance {
-            Some(cli_allowance) => {
-                let allowance = match cli_allowance {
-                    crate::common::NearBalance { inner: num } => num,
-                };
-                Some(allowance)
-            }
+            Some(cli_allowance) => Some(cli_allowance.to_yoctonear()),
             None => FunctionCallType::input_allowance(),
         };
         let receiver_id: near_primitives::types::AccountId = match item.receiver_id {
@@ -118,10 +113,7 @@ impl FunctionCallType {
                     .with_prompt("Enter an allowance which is a balance limit to use by this access key to pay for function call gas and transaction fees.")
                     .interact_text()
                     .unwrap();
-                let allowance = match allowance_near_balance {
-                    crate::common::NearBalance { inner: num } => num,
-                };
-                Some(allowance)
+                Some(allowance_near_balance.to_yoctonear())
             }
             Some(1) => None,
             _ => unreachable!("Error"),

--- a/src/commands/construct_transaction_command/transaction_actions/call_function_type/mod.rs
+++ b/src/commands/construct_transaction_command/transaction_actions/call_function_type/mod.rs
@@ -42,9 +42,7 @@ impl From<CliCallFunctionAction> for CallFunctionAction {
             None => CallFunctionAction::input_gas(),
         };
         let deposit: near_primitives::types::Balance = match item.deposit {
-            Some(cli_deposit) => match cli_deposit {
-                crate::common::NearBalance { inner: num } => num,
-            },
+            Some(cli_deposit) => cli_deposit.to_yoctonear(),
             None => CallFunctionAction::input_deposit(),
         };
         let skip_next_action: super::NextAction = match item.next_action {
@@ -105,12 +103,10 @@ impl CallFunctionAction {
             .with_prompt(
                 "Enter a deposit for function (example: 10NEAR or 0.5near or 10000yoctonear).",
             )
-            .with_initial_text("0 Near")
+            .with_initial_text("0 NEAR")
             .interact_text()
             .unwrap();
-        match deposit {
-            crate::common::NearBalance { inner: num } => num,
-        }
+        deposit.to_yoctonear()
     }
 
     #[async_recursion(?Send)]

--- a/src/commands/execute_command/change_method/call_function_type/mod.rs
+++ b/src/commands/execute_command/change_method/call_function_type/mod.rs
@@ -39,9 +39,7 @@ impl From<CliCallFunctionAction> for CallFunctionAction {
             None => CallFunctionAction::input_gas(),
         };
         let deposit: near_primitives::types::Balance = match item.deposit {
-            Some(cli_deposit) => match cli_deposit {
-                crate::common::NearBalance { inner: num } => num,
-            },
+            Some(cli_deposit) => cli_deposit.to_yoctonear(),
             None => CallFunctionAction::input_deposit(),
         };
         let send_from = match item.send_from {
@@ -102,12 +100,10 @@ impl CallFunctionAction {
             .with_prompt(
                 "Enter a deposit for function (example: 10NEAR or 0.5near or 10000yoctonear).",
             )
-            .with_initial_text("0 Near")
+            .with_initial_text("0 NEAR")
             .interact_text()
             .unwrap();
-        match deposit {
-            crate::common::NearBalance { inner: num } => num,
-        }
+        deposit.to_yoctonear()
     }
 
     pub async fn process(

--- a/src/commands/transfer_command/transfer_near_tokens_type/mod.rs
+++ b/src/commands/transfer_command/transfer_near_tokens_type/mod.rs
@@ -88,11 +88,10 @@ impl TransferNEARTokensAction {
         prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
         selected_server_url: Option<url::Url>,
     ) -> crate::CliResult {
-        let amount = match self.amount {
-            crate::common::NearBalance { inner: num } => num,
-        };
         let action = near_primitives::transaction::Action::Transfer(
-            near_primitives::transaction::TransferAction { deposit: amount },
+            near_primitives::transaction::TransferAction {
+                deposit: self.amount.to_yoctonear(),
+            },
         );
         let mut actions = prepopulated_unsigned_transaction.actions.clone();
         actions.push(action);

--- a/src/commands/view_command/view_account/sender/mod.rs
+++ b/src/commands/view_command/view_account/sender/mod.rs
@@ -70,14 +70,14 @@ impl Sender {
 
     pub async fn process(self, selected_server_url: url::Url) -> crate::CliResult {
         let account_id = self.sender_account_id.clone();
-        self.get_account_info(account_id.clone(), selected_server_url.clone())
+        self.display_account_info(account_id.clone(), selected_server_url.clone())
             .await?;
-        self.get_access_key_list(account_id.clone(), selected_server_url.clone())
+        self.display_access_key_list(account_id.clone(), selected_server_url.clone())
             .await?;
         Ok(())
     }
 
-    async fn get_account_info(
+    async fn display_account_info(
         &self,
         account_id: String,
         selected_server_url: url::Url,
@@ -97,7 +97,7 @@ impl Sender {
                     err
                 ))
             })?;
-        let call_access_view =
+        let account_view =
             if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(result) =
                 query_view_method_response.kind
             {
@@ -105,11 +105,31 @@ impl Sender {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        println!("{:#?}\n", &call_access_view);
+
+        println!(
+            "Account details for '{}' at block #{} ({})\n\
+            Native account balance: {}\n\
+            Validator stake: {}\n\
+            Storage used by the account: {} bytes",
+            account_id,
+            query_view_method_response.block_height,
+            query_view_method_response.block_hash,
+            crate::common::NearBalance::from_yoctonear(account_view.amount),
+            crate::common::NearBalance::from_yoctonear(account_view.locked),
+            account_view.storage_usage
+        );
+        if account_view.code_hash == near_primitives::hash::CryptoHash::default() {
+            println!("Contract code is not deployed to this account.");
+        } else {
+            println!(
+                "Contract code SHA-256 checksum (hex): {}",
+                hex::encode(account_view.code_hash.as_ref())
+            );
+        }
         Ok(())
     }
 
-    async fn get_access_key_list(
+    async fn display_access_key_list(
         &self,
         account_id: String,
         selected_server_url: url::Url,
@@ -118,7 +138,9 @@ impl Sender {
             .rpc_client(&selected_server_url.as_str())
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: near_primitives::types::Finality::Final.into(),
-                request: near_primitives::views::QueryRequest::ViewAccessKeyList { account_id },
+                request: near_primitives::views::QueryRequest::ViewAccessKeyList {
+                    account_id: account_id.clone(),
+                },
             })
             .await
             .map_err(|err| {
@@ -127,7 +149,7 @@ impl Sender {
                     err
                 ))
             })?;
-        let call_access_key_view =
+        let access_key_view =
             if let near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(result) =
                 query_view_method_response.kind
             {
@@ -135,7 +157,39 @@ impl Sender {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        println!("{:#?}", &call_access_key_view);
+
+        println!("Number of access keys: {}", access_key_view.keys.len());
+        for (index, access_key) in access_key_view.keys.iter().enumerate() {
+            let permissions_message = match &access_key.access_key.permission {
+                near_primitives::views::AccessKeyPermissionView::FullAccess => {
+                    "full access".to_owned()
+                }
+                near_primitives::views::AccessKeyPermissionView::FunctionCall {
+                    allowance,
+                    receiver_id,
+                    method_names,
+                } => {
+                    let allowance_message = match allowance {
+                        Some(amount) => format!(
+                            "with an allowance of {}",
+                            crate::common::NearBalance::from_yoctonear(*amount)
+                        ),
+                        None => format!("with no limit"),
+                    };
+                    format!(
+                        "only do {:?} function calls on {} {}",
+                        method_names, receiver_id, allowance_message
+                    )
+                }
+            };
+            println!(
+                "{: >4}. {} (nonce: {}) is granted to {}",
+                index + 1,
+                access_key.public_key,
+                access_key.access_key.nonce,
+                permissions_message
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/304265/119997603-451df680-bfa6-11eb-883f-eeb0398d6544.png)

After:

![image](https://user-images.githubusercontent.com/304265/119997492-29b2eb80-bfa6-11eb-8124-155b9815e0ba.png)

I also refactored `NearBalance`, and had to replace all the usages.