### PR TITLE
Bump gas for a function call to 300Tgas

### DIFF
--- a/src/commands/execute_command/change_method/call_function_type/mod.rs
+++ b/src/commands/execute_command/change_method/call_function_type/mod.rs
@@ -76,10 +76,10 @@ impl CallFunctionAction {
             let gas: u64 = match input_gas {
                 crate::common::NearGas { inner: num } => num,
             };
-            if gas <= 200000000000000 {
+            if gas <= 300000000000000 {
                 break gas;
             } else {
-                println!("You need to enter a value of no more than 200 TERAGAS")
+                println!("You need to enter a value of no more than 300 TERAGAS")
             }
         };
         gas


### PR DESCRIPTION
The maximum gas is limited to 300Tgas, but the burn gas limit is restricted to 200Tgas.